### PR TITLE
add support for retrieving the last N versions of a secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,27 @@ return credstash.get('secret', (e, secret) => {
 });
 ```
 
+## retrieve last N versions of a secret
+
+Credstash support [versioning of secrets](https://github.com/fugue/credstash#versioning-secrets) which allows to easily rotate secrets.
+
+By default node-credstash will return the latest (most recent version of a secret).
+
+You can also retrieve the latest N versions of a secret as follows:
+
+```js
+const Credstash = require('../index.js');
+
+var credstash = new Credstash();
+return credstash.get('secret', {limit: 3}, (e, secrets) => {
+  console.log('this is the last version', secrets[0]);
+  console.log('this is the second-last', secrets[1]);
+  console.log('this is the third-last', secrets[2]);
+});
+```
+
 ## Installation
-Ensure you have [AWS credentials configured](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html). 
+Ensure you have [AWS credentials configured](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html).
 The credentials should be set up as a [secret reader](https://github.com/fugue/credstash#secret-reader)
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -4,18 +4,40 @@ const encoder = require('./lib/encoder');
 const hmac = require('./lib/hmac');
 const keys = require('./lib/keys');
 const secrets = require('./lib/secrets');
+const xtend = require('xtend');
+
+const defaults = {
+  limit: 1
+};
 
 function Credstash(config) {
   this.table = config ? config.table : undefined;
 }
 
-Credstash.prototype.get = function(name, done) {
+Credstash.prototype.get = function(name, options, done) {
+  if (typeof options === 'function') {
+    done = options;
+    options = defaults;
+  } else {
+    options = xtend(defaults, options);
+  }
+
   return async.waterfall([
-    async.apply(secrets.get, this.table, name),
+    async.apply(secrets.get, this.table, name, options),
     async.apply(keys.decrypt),
     async.apply(hmac.check),
     async.apply(decrypter.decrypt)
-  ], done);
+  ], function (err, secrets) {
+    if (err) {
+      return done(err);
+    }
+
+    if (options.limit === 1) {
+      return done(null, secrets && secrets[0]);
+    }
+
+    done(null, secrets);
+  });
 };
 
 module.exports = Credstash;

--- a/lib/decrypter.js
+++ b/lib/decrypter.js
@@ -2,11 +2,15 @@ const aesjs = require('aes-js');
 const encoder = require('./encoder');
 
 module.exports = {
-  decrypt: (stash, done) => {
-    var key = stash.keyPlaintext;
-    var value = encoder.decode(stash.contents);
-    var aesCtr = new aesjs.ModeOfOperation.ctr(key, new aesjs.Counter(1));
-    var decryptedBytes = aesCtr.decrypt(value);
-    return done(null, decryptedBytes.toString());
+  decrypt: (stashes, done) => {
+    const decrypted = stashes.map(stash => {
+      const key = stash.keyPlaintext;
+      const value = encoder.decode(stash.contents);
+      const aesCtr = new aesjs.ModeOfOperation.ctr(key, new aesjs.Counter(1));
+      const decryptedBytes = aesCtr.decrypt(value);
+      return decryptedBytes.toString();
+    });
+
+    return done(null, decrypted);
   }
 };

--- a/lib/hmac.js
+++ b/lib/hmac.js
@@ -2,15 +2,18 @@ const crypto = require('crypto');
 const encoder = require('./encoder');
 
 module.exports = {
-  check: (stash, done) => {
-    var hmac = crypto.createHmac('sha256', stash.hmacPlaintext);
-    var contents = encoder.decode(stash.contents);
-    hmac.update(contents);
+  check: (stashes, done) => {
+    const wrongMacs = stashes.filter(stash => {
+      const hmac = crypto.createHmac('sha256', stash.hmacPlaintext);
+      const contents = encoder.decode(stash.contents);
+      hmac.update(contents);
+      return hmac.digest('hex') !== stash.hmac;
+    });
 
-    if (hmac.digest('hex') !== stash.hmac) {
+    if (wrongMacs.length > 0) {
       return done(new Error('Computed HMAC does not match store HMAC'));
     }
 
-    return done(null, stash);
+    return done(null, stashes);
   }
 };

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -6,23 +6,26 @@ function decrypt(key, done) {
   var params = {
     CiphertextBlob: encoder.decode(key)
   };
-  
-  return new AWS.KMS().decrypt(params, done); 
+
+  return new AWS.KMS().decrypt(params, done);
 }
 
-function split(stash, decrypted, done) {
-  stash.keyPlaintext = new Buffer(32);
-  stash.hmacPlaintext = new Buffer(32);
-  decrypted.Plaintext.copy(stash.keyPlaintext, 0, 0, 32);
-  decrypted.Plaintext.copy(stash.hmacPlaintext, 0, 32);
-  return done(null, stash);
+function split(stashes, decryptedKeys, done) {
+  var result = stashes.map((stash, index) => {
+    stash.keyPlaintext = new Buffer(32);
+    stash.hmacPlaintext = new Buffer(32);
+    decryptedKeys[index].Plaintext.copy(stash.keyPlaintext, 0, 0, 32);
+    decryptedKeys[index].Plaintext.copy(stash.hmacPlaintext, 0, 32);
+    return stash;
+  });
+  return done(null, result);
 }
 
 module.exports = {
-  decrypt: (stash, done) => {
-  return async.waterfall([
-    async.apply(decrypt, stash.key),
-    async.apply(split, stash)
-  ], done);
+  decrypt: (stashes, done) => {
+    return async.waterfall([
+      async.apply(async.map, stashes.map(s => s.key), decrypt),
+      async.apply(split, stashes)
+    ], done);
   }
-}
+};

--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -1,11 +1,11 @@
 const AWS = require('aws-sdk');
 const async = require('async');
 
-function find(table, name, done) {
+function find(table, name, options, done) {
   var params = {
     TableName: table || 'credential-store',
     ConsistentRead: true,
-    Limit: 1,
+    Limit: options.limit,
     ScanIndexForward: false,
     KeyConditions: {
       name: {
@@ -21,25 +21,23 @@ function find(table, name, done) {
 }
 
 function map(name, data, done) {
-  if (!data.Items || data.Items.length != 1) {
+  if (!data.Items || data.Items.length === 0) {
     return done(new Error('secret not found: ' + name));
   }
 
-  var item = data.Items[0];
-
-  var stash = {
+  var result = data.Items.map(item => ({
     key: item.key.S,
     hmac: item.hmac.S,
     contents: item.contents.S
-  };
+  }));
 
-  return done(null, stash);
+  return done(null, result);
 }
 
 module.exports = {
-  get: (table, name, done) => {
+  get: (table, name, options, done) => {
     return async.waterfall([
-      async.apply(find, table, name),
+      async.apply(find, table, name, options),
       async.apply(map, name),
     ], done);
   }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "aes-js": "0.2.2",
     "async": "1.5.2",
-    "aws-sdk": "2.2.35"
+    "aws-sdk": "2.2.35",
+    "xtend": "4.0.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,19 @@ describe('credstash', () => {
     });
   });
 
+  it('can get N versions of a secret', (done) => {
+    AWS.mock('DynamoDB', 'query', mockQueryWithTake('credential-store'));
+    AWS.mock('KMS', 'decrypt', mockKMS);
+    var credstash = new Credstash();
+    return credstash.get('secret', { limit: 3 }, (e, secrets) => {
+      should.not.exist(e);
+      secrets[0].should.equal('magic');
+      secrets[1].should.equal('magic');
+      secrets[2].should.equal('magic');
+      return done();
+    });
+  });
+
   it('can get secret from alternative table', (done) => {
     AWS.mock('DynamoDB', 'query', mockQuery('another-table'));
     AWS.mock('KMS', 'decrypt', mockKMS);
@@ -45,6 +58,48 @@ var mockQuery = (expectedTable) => {
     params.TableName.should.equal(expectedTable);
     var ret = {
       Items: [{
+        key: {
+          S: 'CiBzvX0zBm6hGu0EnbpRJ+eO+HfPOIsG5oq1UDiK+pi/vBLLAQEBAQB4c719MwZuoRrtBJ26USfnjvh3zziLBuaKtVA4ivqYv7wAAACiMIGfBgkqhkiG9w0BBwaggZEwgY4CAQAwgYgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKNQYv5K9wPp+EvLQAgEQgFsITbvzf75MiY6aeIG2v/OzH2ThW5EJrfgNSekCGXONJSs3R8qkOlxFOfnoISvCXylMwBr+iAZFydgZiSyudPE+qocnYi++aVsv+iV9rR7o+FGQtSWKj2UH9PHm'
+        },
+        hmac: {
+          S: 'ada335c27410033b16887d083aba629c17ad8f88b7982f331e4f6f8df92c41a9'
+        },
+        contents: {
+          S: 'H2T+k+c='
+        }
+      }]
+    };
+
+    return done(null, ret);
+  };
+};
+
+var mockQueryWithTake = (expectedTable) => {
+  return (params, done) => {
+    params.Limit.should.equal(3);
+    params.TableName.should.equal(expectedTable);
+    var ret = {
+      Items: [{
+        key: {
+          S: 'CiBzvX0zBm6hGu0EnbpRJ+eO+HfPOIsG5oq1UDiK+pi/vBLLAQEBAQB4c719MwZuoRrtBJ26USfnjvh3zziLBuaKtVA4ivqYv7wAAACiMIGfBgkqhkiG9w0BBwaggZEwgY4CAQAwgYgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKNQYv5K9wPp+EvLQAgEQgFsITbvzf75MiY6aeIG2v/OzH2ThW5EJrfgNSekCGXONJSs3R8qkOlxFOfnoISvCXylMwBr+iAZFydgZiSyudPE+qocnYi++aVsv+iV9rR7o+FGQtSWKj2UH9PHm'
+        },
+        hmac: {
+          S: 'ada335c27410033b16887d083aba629c17ad8f88b7982f331e4f6f8df92c41a9'
+        },
+        contents: {
+          S: 'H2T+k+c='
+        }
+      },{
+        key: {
+          S: 'CiBzvX0zBm6hGu0EnbpRJ+eO+HfPOIsG5oq1UDiK+pi/vBLLAQEBAQB4c719MwZuoRrtBJ26USfnjvh3zziLBuaKtVA4ivqYv7wAAACiMIGfBgkqhkiG9w0BBwaggZEwgY4CAQAwgYgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKNQYv5K9wPp+EvLQAgEQgFsITbvzf75MiY6aeIG2v/OzH2ThW5EJrfgNSekCGXONJSs3R8qkOlxFOfnoISvCXylMwBr+iAZFydgZiSyudPE+qocnYi++aVsv+iV9rR7o+FGQtSWKj2UH9PHm'
+        },
+        hmac: {
+          S: 'ada335c27410033b16887d083aba629c17ad8f88b7982f331e4f6f8df92c41a9'
+        },
+        contents: {
+          S: 'H2T+k+c='
+        }
+      },{
         key: {
           S: 'CiBzvX0zBm6hGu0EnbpRJ+eO+HfPOIsG5oq1UDiK+pi/vBLLAQEBAQB4c719MwZuoRrtBJ26USfnjvh3zziLBuaKtVA4ivqYv7wAAACiMIGfBgkqhkiG9w0BBwaggZEwgY4CAQAwgYgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKNQYv5K9wPp+EvLQAgEQgFsITbvzf75MiY6aeIG2v/OzH2ThW5EJrfgNSekCGXONJSs3R8qkOlxFOfnoISvCXylMwBr+iAZFydgZiSyudPE+qocnYi++aVsv+iV9rR7o+FGQtSWKj2UH9PHm'
         },


### PR DESCRIPTION
Credstash support [versioning of secrets](https://github.com/fugue/credstash#versioning-secrets) which allows to easily rotate secrets.

With this change node-credstash will keep its current behavior of returning the latest version of a secret by default.

I added a new option `limit`, to get the latest N versions of a secret:

``` js
const Credstash = require('../index.js');

var credstash = new Credstash();
return credstash.get('secret', { limit: 3 }, (e, secrets) => {
  console.log('this is the last version', secrets[0]);
  console.log('this is the second-last', secrets[1]);
  console.log('this is the third-last', secrets[2]);
});
```

If `options.limit: 1` or if you don't pass the options parameters, the callback receives `secret` (singular). So, this change is backward compatible.
