### PR TITLE
Add support for retrieving specific versions of credentials

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -1,6 +1,9 @@
 const AWS = require('aws-sdk');
 const async = require('async');
 const encoder = require('./encoder');
+if (typeof process.env.AWS_DEFAULT_REGION !== 'undefined') {
+  AWS.config.update({region: process.env.AWS_DEFAULT_REGION});
+}
 
 function decrypt(key, done) {
   var params = {

--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -1,5 +1,18 @@
 const AWS = require('aws-sdk');
 const async = require('async');
+const PAD_LEN = 19;
+if (typeof process.env.AWS_DEFAULT_REGION !== 'undefined') {
+  AWS.config.update({region: process.env.AWS_DEFAULT_REGION});
+}
+
+// Blatantly borrowed from https://www.electrictoolbox.com/pad-number-zeroes-javascript/
+function pad(number, length) {
+  var str = '' + number;
+  while (str.length < length) {
+    str = '0' + str;
+  }
+  return str;
+}
 
 function find(table, name, options, done) {
   var params = {
@@ -7,15 +20,33 @@ function find(table, name, options, done) {
     ConsistentRead: true,
     Limit: options.limit,
     ScanIndexForward: false,
-    KeyConditions: {
+  };
+  if (options.version !== 'undefined') {
+    params.KeyConditions = {
+      name: {
+        ComparisonOperator: 'EQ',
+        AttributeValueList: [{
+          S: name
+        }]
+      },
+      version: {
+        ComparisonOperator: 'EQ',
+        AttributeValueList: [{
+          S: pad(options.version, PAD_LEN)
+        }]
+      }
+    };
+  }
+  else {
+    param.KeyConditions = {
       name: {
         ComparisonOperator: 'EQ',
         AttributeValueList: [{
           S: name
         }]
       }
-    }
-  };
+    };
+  }
 
   return new AWS.DynamoDB().query(params, done);
 }


### PR DESCRIPTION
Suggested solution for https://github.com/roylines/node-credstash/issues/9.

* Used the available `options` construct to pass `version`
* If `options.version` is passed, add an extra filter for the DynamoDB column
* Credstash uses a special padded string for version data

Also, I added support for AWS region, as the JS SDK doesn't pull that by default from the environment. This makes development from the CLI a bit easier. I didn't DRY/modularize because we only instantiate `AWS` in two places.

We probably want to update test case scenarios to include the passing of a {version: 1}.

I'm uncertain if this boggles any of the existing version handling logic (this is my first JS project), but it works perfectly with my local use case.