### PR TITLE
Add support for .list without changing current API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -7,8 +7,15 @@ Node.js module for reading [credstash](https://github.com/fugue/credstash) secre
 const Credstash = require('../index.js');
 
 var credstash = new Credstash();
+
+// .get method for one key (table query)
 return credstash.get('secret', (e, secret) => {
   console.log('do not share the secret', secret);
+});
+
+// .list method for multiple keys (table scan)
+return credstash.list((e, secrets) => {
+  console.log('do not share the secrets', secrets);
 });
 ```
 
@@ -44,4 +51,3 @@ return credstash.get('secret', {limit: 3}, (e, secrets) => {
   console.log('this is the third-last', secrets[2]);
 });
 ```
-

--- a/index.js
+++ b/index.js
@@ -14,6 +14,28 @@ function Credstash(config) {
   this.table = config ? config.table : undefined;
 }
 
+Credstash.prototype.list = function(options, done) {
+  if (typeof options === 'function') {
+    done = options;
+    options = defaults;
+  } else {
+    options = xtend(defaults, options);
+  }
+
+  return async.waterfall([
+    async.apply(secrets.list, this.table, options),
+    async.apply(keys.decrypt),
+    async.apply(hmac.check),
+    async.apply(decrypter.decryptedObject)
+  ], function (err, secrets) {
+    if (err) {
+      return done(err);
+    }
+
+    done(null, secrets);
+  });
+};
+
 Credstash.prototype.get = function(name, options, done) {
   if (typeof options === 'function') {
     done = options;
@@ -26,7 +48,7 @@ Credstash.prototype.get = function(name, options, done) {
     async.apply(secrets.get, this.table, name, options),
     async.apply(keys.decrypt),
     async.apply(hmac.check),
-    async.apply(decrypter.decrypt)
+    async.apply(decrypter.decryptedList)
   ], function (err, secrets) {
     if (err) {
       return done(err);

--- a/lib/decrypter.js
+++ b/lib/decrypter.js
@@ -1,16 +1,26 @@
 const aesjs = require('aes-js');
 const encoder = require('./encoder');
 
-module.exports = {
-  decrypt: (stashes, done) => {
-    const decrypted = stashes.map(stash => {
-      const key = stash.keyPlaintext;
-      const value = encoder.decode(stash.contents);
-      const aesCtr = new aesjs.ModeOfOperation.ctr(key, new aesjs.Counter(1));
-      const decryptedBytes = aesCtr.decrypt(value);
-      return decryptedBytes.toString();
-    });
+function decryptedString(stash) {
+  const key = stash.keyPlaintext;
+  const value = encoder.decode(stash.contents);
+  const aesCtr = new aesjs.ModeOfOperation.ctr(key, new aesjs.Counter(1));
+  const decryptedBytes = aesCtr.decrypt(value);
+  return decryptedBytes.toString();
+}
 
+module.exports = {
+  decryptedList: (stashes, done) => {
+    const decrypted = stashes.map(stash => {
+      return decryptedString(stash);
+    });
+    return done(null, decrypted);
+  },
+  decryptedObject: (stashes, done) => {
+    const decrypted = stashes.reduce((acc, stash) => {
+      acc[stash.name] = decryptedString(stash);
+      return acc;
+    }, {});
     return done(null, decrypted);
   }
 };

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -1,7 +1,8 @@
 const AWS = require('aws-sdk');
 const async = require('async');
 const encoder = require('./encoder');
-if (typeof process.env.AWS_DEFAULT_REGION !== 'undefined') {
+
+if (typeof process.env.AWS_DEFAULT_REGION !== undefined) {
   AWS.config.update({region: process.env.AWS_DEFAULT_REGION});
 }
 

--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -1,17 +1,40 @@
 const AWS = require('aws-sdk');
 const async = require('async');
-const PAD_LEN = 19;
-if (typeof process.env.AWS_DEFAULT_REGION !== 'undefined') {
+
+if (typeof process.env.AWS_DEFAULT_REGION !== undefined) {
   AWS.config.update({region: process.env.AWS_DEFAULT_REGION});
 }
 
 // Blatantly borrowed from https://www.electrictoolbox.com/pad-number-zeroes-javascript/
 function pad(number, length) {
-  var str = '' + number;
+  let str = '' + number;
   while (str.length < length) {
     str = '0' + str;
   }
   return str;
+}
+
+function makeVersion(version, padLen = 19) {
+  return {
+    ComparisonOperator: 'EQ',
+    AttributeValueList: [{
+      S: pad(version, padLen)
+    }]
+  };
+}
+
+function scan(table, options, done) {
+  var params = {
+    TableName: table || 'credential-store',
+    ConsistentRead: true,
+    ScanFilter: {}
+  };
+
+  if (options.version !== undefined) {
+      params.ScanFilter.version = makeVersion(options.version);
+  }
+
+  return new AWS.DynamoDB().scan(params, done);
 }
 
 function find(table, name, options, done) {
@@ -20,32 +43,18 @@ function find(table, name, options, done) {
     ConsistentRead: true,
     Limit: options.limit,
     ScanIndexForward: false,
+    KeyConditions: {
+      name: {
+        ComparisonOperator: 'EQ',
+        AttributeValueList: [{
+          S: name
+        }]
+      }
+    }
   };
-  if (options.version !== 'undefined') {
-    params.KeyConditions = {
-      name: {
-        ComparisonOperator: 'EQ',
-        AttributeValueList: [{
-          S: name
-        }]
-      },
-      version: {
-        ComparisonOperator: 'EQ',
-        AttributeValueList: [{
-          S: pad(options.version, PAD_LEN)
-        }]
-      }
-    };
-  }
-  else {
-    param.KeyConditions = {
-      name: {
-        ComparisonOperator: 'EQ',
-        AttributeValueList: [{
-          S: name
-        }]
-      }
-    };
+
+  if (options.version !== undefined) {
+    params.KeyConditions.version = makeVersion(options.version);
   }
 
   return new AWS.DynamoDB().query(params, done);
@@ -57,6 +66,7 @@ function map(name, data, done) {
   }
 
   var result = data.Items.map(item => ({
+    name: item.name.S,
     key: item.key.S,
     hmac: item.hmac.S,
     contents: item.contents.S
@@ -70,6 +80,12 @@ module.exports = {
     return async.waterfall([
       async.apply(find, table, name, options),
       async.apply(map, name),
+    ], done);
+  },
+  list: (table, options, done) => {
+    return async.waterfall([
+      async.apply(scan, table, options),
+      async.apply(map, 'all secrets'),
     ], done);
   }
 };

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,19 @@ describe('credstash', () => {
     AWS.restore();
   });
 
+  it('can get a list secrets', (done) => {
+    AWS.mock('DynamoDB', 'scan', mockScanWithTake('credential-store'));
+    AWS.mock('KMS', 'decrypt', mockKMS);
+    var credstash = new Credstash();
+    return credstash.list({ limit: 3 }, (e, secrets) => {
+      should.not.exist(e);
+      secrets['name1'].should.equal('magic');
+      secrets['name2'].should.equal('magic');
+      secrets['name3'].should.equal('magic');
+      return done();
+    });
+  });
+
   it('can get secret', (done) => {
     AWS.mock('DynamoDB', 'query', mockQuery('credential-store'));
     AWS.mock('KMS', 'decrypt', mockKMS);
@@ -58,6 +71,9 @@ var mockQuery = (expectedTable) => {
     params.TableName.should.equal(expectedTable);
     var ret = {
       Items: [{
+        name: {
+          S: 'name'
+        },
         key: {
           S: 'CiBzvX0zBm6hGu0EnbpRJ+eO+HfPOIsG5oq1UDiK+pi/vBLLAQEBAQB4c719MwZuoRrtBJ26USfnjvh3zziLBuaKtVA4ivqYv7wAAACiMIGfBgkqhkiG9w0BBwaggZEwgY4CAQAwgYgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKNQYv5K9wPp+EvLQAgEQgFsITbvzf75MiY6aeIG2v/OzH2ThW5EJrfgNSekCGXONJSs3R8qkOlxFOfnoISvCXylMwBr+iAZFydgZiSyudPE+qocnYi++aVsv+iV9rR7o+FGQtSWKj2UH9PHm'
         },
@@ -80,6 +96,9 @@ var mockQueryWithTake = (expectedTable) => {
     params.TableName.should.equal(expectedTable);
     var ret = {
       Items: [{
+        name: {
+          S: 'name'
+        },
         key: {
           S: 'CiBzvX0zBm6hGu0EnbpRJ+eO+HfPOIsG5oq1UDiK+pi/vBLLAQEBAQB4c719MwZuoRrtBJ26USfnjvh3zziLBuaKtVA4ivqYv7wAAACiMIGfBgkqhkiG9w0BBwaggZEwgY4CAQAwgYgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKNQYv5K9wPp+EvLQAgEQgFsITbvzf75MiY6aeIG2v/OzH2ThW5EJrfgNSekCGXONJSs3R8qkOlxFOfnoISvCXylMwBr+iAZFydgZiSyudPE+qocnYi++aVsv+iV9rR7o+FGQtSWKj2UH9PHm'
         },
@@ -90,6 +109,9 @@ var mockQueryWithTake = (expectedTable) => {
           S: 'H2T+k+c='
         }
       },{
+        name: {
+          S: 'name'
+        },
         key: {
           S: 'CiBzvX0zBm6hGu0EnbpRJ+eO+HfPOIsG5oq1UDiK+pi/vBLLAQEBAQB4c719MwZuoRrtBJ26USfnjvh3zziLBuaKtVA4ivqYv7wAAACiMIGfBgkqhkiG9w0BBwaggZEwgY4CAQAwgYgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKNQYv5K9wPp+EvLQAgEQgFsITbvzf75MiY6aeIG2v/OzH2ThW5EJrfgNSekCGXONJSs3R8qkOlxFOfnoISvCXylMwBr+iAZFydgZiSyudPE+qocnYi++aVsv+iV9rR7o+FGQtSWKj2UH9PHm'
         },
@@ -100,6 +122,58 @@ var mockQueryWithTake = (expectedTable) => {
           S: 'H2T+k+c='
         }
       },{
+        name: {
+          S: 'name'
+        },
+        key: {
+          S: 'CiBzvX0zBm6hGu0EnbpRJ+eO+HfPOIsG5oq1UDiK+pi/vBLLAQEBAQB4c719MwZuoRrtBJ26USfnjvh3zziLBuaKtVA4ivqYv7wAAACiMIGfBgkqhkiG9w0BBwaggZEwgY4CAQAwgYgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKNQYv5K9wPp+EvLQAgEQgFsITbvzf75MiY6aeIG2v/OzH2ThW5EJrfgNSekCGXONJSs3R8qkOlxFOfnoISvCXylMwBr+iAZFydgZiSyudPE+qocnYi++aVsv+iV9rR7o+FGQtSWKj2UH9PHm'
+        },
+        hmac: {
+          S: 'ada335c27410033b16887d083aba629c17ad8f88b7982f331e4f6f8df92c41a9'
+        },
+        contents: {
+          S: 'H2T+k+c='
+        }
+      }]
+    };
+
+    return done(null, ret);
+  };
+};
+var mockScanWithTake = (expectedTable) => {
+  return (params, done) => {
+    params.TableName.should.equal(expectedTable);
+    var ret = {
+      Items: [{
+        name: {
+          S: 'name1'
+        },
+        key: {
+          S: 'CiBzvX0zBm6hGu0EnbpRJ+eO+HfPOIsG5oq1UDiK+pi/vBLLAQEBAQB4c719MwZuoRrtBJ26USfnjvh3zziLBuaKtVA4ivqYv7wAAACiMIGfBgkqhkiG9w0BBwaggZEwgY4CAQAwgYgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKNQYv5K9wPp+EvLQAgEQgFsITbvzf75MiY6aeIG2v/OzH2ThW5EJrfgNSekCGXONJSs3R8qkOlxFOfnoISvCXylMwBr+iAZFydgZiSyudPE+qocnYi++aVsv+iV9rR7o+FGQtSWKj2UH9PHm'
+        },
+        hmac: {
+          S: 'ada335c27410033b16887d083aba629c17ad8f88b7982f331e4f6f8df92c41a9'
+        },
+        contents: {
+          S: 'H2T+k+c='
+        }
+      },{
+        name: {
+          S: 'name2'
+        },
+        key: {
+          S: 'CiBzvX0zBm6hGu0EnbpRJ+eO+HfPOIsG5oq1UDiK+pi/vBLLAQEBAQB4c719MwZuoRrtBJ26USfnjvh3zziLBuaKtVA4ivqYv7wAAACiMIGfBgkqhkiG9w0BBwaggZEwgY4CAQAwgYgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKNQYv5K9wPp+EvLQAgEQgFsITbvzf75MiY6aeIG2v/OzH2ThW5EJrfgNSekCGXONJSs3R8qkOlxFOfnoISvCXylMwBr+iAZFydgZiSyudPE+qocnYi++aVsv+iV9rR7o+FGQtSWKj2UH9PHm'
+        },
+        hmac: {
+          S: 'ada335c27410033b16887d083aba629c17ad8f88b7982f331e4f6f8df92c41a9'
+        },
+        contents: {
+          S: 'H2T+k+c='
+        }
+      },{
+        name: {
+          S: 'name3'
+        },
         key: {
           S: 'CiBzvX0zBm6hGu0EnbpRJ+eO+HfPOIsG5oq1UDiK+pi/vBLLAQEBAQB4c719MwZuoRrtBJ26USfnjvh3zziLBuaKtVA4ivqYv7wAAACiMIGfBgkqhkiG9w0BBwaggZEwgY4CAQAwgYgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKNQYv5K9wPp+EvLQAgEQgFsITbvzf75MiY6aeIG2v/OzH2ThW5EJrfgNSekCGXONJSs3R8qkOlxFOfnoISvCXylMwBr+iAZFydgZiSyudPE+qocnYi++aVsv+iV9rR7o+FGQtSWKj2UH9PHm'
         },


### PR DESCRIPTION
Hi, we need support for listing all (or a filtered set) of keys from a table vs. one at a time.

I tried to make this update as minimal as I could and have not changed the existing API.

There is a new test for `.list`.

Thanks for making this lib!