### PR TITLE
Fix .list to be compatible with node 4.0.0

### DIFF
--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -7,7 +7,7 @@ if (typeof process.env.AWS_DEFAULT_REGION !== undefined) {
 
 // Blatantly borrowed from https://www.electrictoolbox.com/pad-number-zeroes-javascript/
 function pad(number, length) {
-  let str = '' + number;
+  var str = '' + number;
   while (str.length < length) {
     str = '0' + str;
   }

--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -14,11 +14,11 @@ function pad(number, length) {
   return str;
 }
 
-function makeVersion(version, padLen = 19) {
+function makeVersion(version) {
   return {
     ComparisonOperator: 'EQ',
     AttributeValueList: [{
-      S: pad(version, padLen)
+      S: pad(version, 19)
     }]
   };
 }


### PR DESCRIPTION
I didn't realize until I saw the CircleCI failed build that the tests are running in Node v4.

Should be fixed now.