### PR TITLE
Add support for getting ECS style authentication

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -1,0 +1,20 @@
+const AWS = require('aws-sdk');
+
+console.log(`URI: ${process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}`);
+
+if (typeof process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI !== 'undefined') {
+  console.log('CREDS');
+
+  AWS.config.credentials = new AWS.ECSCredentials({
+    httpOptions: { timeout: 5000 },
+    maxRetries: 10,
+    retryDelayOptions: { base: 200 }
+  });
+
+}
+
+if (typeof process.env.AWS_DEFAULT_REGION !== 'undefined') {
+  AWS.config.update({region: process.env.AWS_DEFAULT_REGION});
+}
+
+module.exports = AWS;

--- a/lib/aws.js
+++ b/lib/aws.js
@@ -1,16 +1,11 @@
 const AWS = require('aws-sdk');
 
-console.log(`URI: ${process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}`);
-
 if (typeof process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI !== 'undefined') {
-  console.log('CREDS');
-
   AWS.config.credentials = new AWS.ECSCredentials({
     httpOptions: { timeout: 5000 },
     maxRetries: 10,
     retryDelayOptions: { base: 200 }
   });
-
 }
 
 if (typeof process.env.AWS_DEFAULT_REGION !== 'undefined') {

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -1,10 +1,6 @@
-const AWS = require('aws-sdk');
+const AWS = require('./aws');
 const async = require('async');
 const encoder = require('./encoder');
-
-if (typeof process.env.AWS_DEFAULT_REGION !== 'undefined') {
-  AWS.config.update({region: process.env.AWS_DEFAULT_REGION});
-}
 
 function decrypt(key, done) {
   var params = {

--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -1,9 +1,5 @@
-const AWS = require('aws-sdk');
 const async = require('async');
-
-if (typeof process.env.AWS_DEFAULT_REGION !== 'undefined') {
-  AWS.config.update({region: process.env.AWS_DEFAULT_REGION});
-}
+const AWS = require('./aws');
 
 // Blatantly borrowed from https://www.electrictoolbox.com/pad-number-zeroes-javascript/
 function pad(number, length) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "aes-js": "0.2.2",
     "async": "1.5.2",
-    "aws-sdk": "2.2.35",
+    "aws-sdk": "2.28.0",
     "xtend": "4.0.1"
   }
 }

--- a/test/aws.js
+++ b/test/aws.js
@@ -1,0 +1,16 @@
+const should = require('chai').should();
+
+describe('AWS', () => {
+  const env = Object.assign({}, process.env);
+  process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI = 'https://fake-uri';
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  it('can work with ecs credentials', (done) => {
+    const AWS = require('../lib/aws.js');
+    AWS.config.credentials.should.be.an.instanceOf(AWS.ECSCredentials);
+    done();
+  });
+});


### PR DESCRIPTION
When running `Credstash` inside ECS as a docker container, the
authentication is being "injected" as an assumed role.

This PR adds support for checking whether the context the task is being
ran in is ECS, if it is, it will instanciate the special object to grab
the auth from the ECS proxy.

BEFORE:

When trying to run the task, it would assume the role of the instance
it's running on (which may or may not have the permissions you want).

```
User `<instance-role>' is not authorized to perform `<specific-task>' on resource `<some-resource>'
```

After:

Task is running as expected and assuming the correct role.

All tests are passing

Some more changes

* Instead of requiring and customizing the AWS sdk in multiple places,
put it in a single file and customizing only there.
* Added tests for the right credentials being passed in
* Checking whether we are in ECS context based on a special ENV var only
passed from there