### PR TITLE
Credstash changed hmac type from string to binary

### DIFF
--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -68,7 +68,7 @@ function map(name, data, done) {
   var result = data.Items.map(item => ({
     name: item.name.S,
     key: item.key.S,
-    hmac: item.hmac.S,
+    hmac: ('S' in item.hmac) ? item.hmac.S : item.hmac.B.toString('utf8'),
     contents: item.contents.S
   }));
 


### PR DESCRIPTION
Fixes the issue introduced by credstash fugue/credstash#154, where the hmac value in dynamodb is binary instead of the expected string type