### PR TITLE
mv aws-sdk to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "url": "https://github.com/roylines/node-credstash/issues"
   },
   "homepage": "https://github.com/roylines/node-credstash#readme",
+  "peerDependencies": {
+    "aws-sdk": "*"
+  },
   "devDependencies": {
     "aws-sdk-mock": "1.0.5",
     "chai": "3.5.0",
@@ -34,7 +37,6 @@
   "dependencies": {
     "aes-js": "0.2.2",
     "async": "1.5.2",
-    "aws-sdk": "2.2.35",
     "xtend": "4.0.1"
   }
 }


### PR DESCRIPTION
Since the aws sdk keeps some internal private vars eg: when doing `AWS.config.update` the sdk shouldn't be embeded, it's best to have it as a peer dependency.

The issue I had is that setting AWS_DEFAULT_REGION would have no effect as it would set it within the sdk embeded in the credstash module, but not the parent module using it
